### PR TITLE
Fix incorrect response handling in verifyUser:

### DIFF
--- a/frontend/src/pages/UserVerifyPage.tsx
+++ b/frontend/src/pages/UserVerifyPage.tsx
@@ -14,6 +14,7 @@ const UserVerifyPage: React.FC = () => {
       verifyUser(token)
         .then((response) => {
           console.log("response", response);
+          console.log("response.message", response?.message);
           if (
             response &&
             response.message === "Your email has been successfully verified!"

--- a/frontend/src/service/user.service.ts
+++ b/frontend/src/service/user.service.ts
@@ -38,7 +38,7 @@ export const verifyUser = async (
       console.warn("Expected JSON, got something else.");
       return null;
     }
-    return response.data.message;
+    return response.data;
   } catch (error) {
     console.error("Error", error);
     return null;


### PR DESCRIPTION
Return full API response instead of just message string to ensure frontend can access response.message properly